### PR TITLE
Ensure the -std=c++11 flag is set as part of PKG_CXXFLAGS

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,6 @@
 ## -*- mode: makefile; -*-
 
 CXX_STD = CXX11
+PKG_CXXFLAGS = '-std=c++11'
 PKG_CPPFLAGS = -I../inst/cppzmq
 PKG_LIBS = -lzmq


### PR DESCRIPTION
Fixes #12 by ensuring c++11 is used (so that `static_assert` is available).
