### PR TITLE
Add XREQ, XREP socket types

### DIFF
--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -73,6 +73,10 @@ int string_to_socket_type(const std::string s) {
     return ZMQ_XPUB;
   } else if(s == "ZMQ_XSUB") {
     return ZMQ_XSUB;
+  } else if(s == "ZMQ_XREQ") {
+    return ZMQ_XREQ;
+  } else if(s == "ZMQ_XREP") {
+    return ZMQ_XREP;
   } else {
     return -1;
   }


### PR DESCRIPTION
The current `rzmq` version will report *socket type not found* when trying to create a `ZMQ_XREQ` or `ZMQ_XREP` socket used for [forwarding `REQ`/`REP` connections](http://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/devices/queue.html).

The only reason why is fails is that the corresponding socket types are not listed in `string_to_socket_type()`.

If they are added, these sockets work without a problem within `rzmq`.

There should also be no problem with older `ZeroMQ` versions, as this socket type was available [from version 3](http://www.360doc.com/content/12/0517/15/4910_211664046.shtml).