### PR TITLE
poll timeout in ms not us

### DIFF
--- a/R/rzmq.R
+++ b/R/rzmq.R
@@ -105,7 +105,7 @@ receive.double <- function(socket) {
 }
 
 poll.socket <- function(sockets, events, timeout=0L) {
-    if (timeout != -1L) timeout <- as.integer(timeout * 1000000)
+    if (timeout != -1L) timeout <- as.integer(timeout * 1e3)
     .Call("pollSocket", sockets, events, timeout)
 }
 


### PR DESCRIPTION
`rzmq` documentation states that the `timeout` in `poll.socket` is to be specified in seconds.

ZMQ [2.x had microseconds](http://api.zeromq.org/2-1:zmq-poll), but for ZMQ 3.0 the timeout should be passed [as milliseconds](http://api.zeromq.org/3-0:zmq-poll).

Since `rzmq` depends on ZMQ>=3, the correct multiplier her is `1e3`, not `1e6`.