### PR TITLE
Exposing functions related to CurveZMQ authentication.

### DIFF
--- a/R/rzmq.R
+++ b/R/rzmq.R
@@ -16,27 +16,27 @@
 ###########################################################################
 
 zmq.errno <- function() {
-    .Call("get_zmq_errno", PACKAGE="rzmq2")
+    .Call("get_zmq_errno", PACKAGE="rzmq")
 }
 
 zmq.strerror <- function() {
-    .Call("get_zmq_strerror", PACKAGE="rzmq2")
+    .Call("get_zmq_strerror", PACKAGE="rzmq")
 }
 
 init.socket <- function(context, socket.type) {
-    .Call("initSocket", context, socket.type, PACKAGE="rzmq2")
+    .Call("initSocket", context, socket.type, PACKAGE="rzmq")
 }
 
 bind.socket <- function(socket, address) {
-    invisible(.Call("bindSocket", socket, address, PACKAGE="rzmq2"))
+    invisible(.Call("bindSocket", socket, address, PACKAGE="rzmq"))
 }
 
 connect.socket <- function(socket, address) {
-    invisible(.Call("connectSocket", socket, address, PACKAGE="rzmq2"))
+    invisible(.Call("connectSocket", socket, address, PACKAGE="rzmq"))
 }
 
 disconnect.socket <- function(socket, address) {
-    invisible(.Call("disconnectSocket", socket, address, PACKAGE="rzmq2"))
+    invisible(.Call("disconnectSocket", socket, address, PACKAGE="rzmq"))
 }
 
 send.socket <- function(socket, data, send.more=FALSE, serialize=TRUE,
@@ -45,19 +45,19 @@ send.socket <- function(socket, data, send.more=FALSE, serialize=TRUE,
         data <- serialize(data, NULL, xdr=xdr)
     }
 
-    invisible(.Call("sendSocket", socket, data, send.more, PACKAGE="rzmq2"))
+    invisible(.Call("sendSocket", socket, data, send.more, PACKAGE="rzmq"))
 }
 
 send.null.msg <- function(socket, send.more=FALSE) {
-    .Call("sendNullMsg", socket, send.more, PACKAGE="rzmq2")
+    .Call("sendNullMsg", socket, send.more, PACKAGE="rzmq")
 }
 
 receive.null.msg <- function(socket) {
-    .Call("receiveNullMsg", socket, PACKAGE="rzmq2")
+    .Call("receiveNullMsg", socket, PACKAGE="rzmq")
 }
 
 receive.socket <- function(socket, unserialize=TRUE,dont.wait=FALSE) {
-    ans <- .Call("receiveSocket", socket, dont.wait, PACKAGE="rzmq2")
+    ans <- .Call("receiveSocket", socket, dont.wait, PACKAGE="rzmq")
 
     if(!is.null(ans) && unserialize) {
         ans <- unserialize(ans)
@@ -81,19 +81,19 @@ send.multipart <- function(socket, parts) {
 }
 
 send.raw.string <- function(socket,data,send.more=FALSE) {
-    .Call("sendRawString", socket, data, send.more, PACKAGE="rzmq2")
+    .Call("sendRawString", socket, data, send.more, PACKAGE="rzmq")
 }
 
 receive.string <- function(socket) {
-    .Call("receiveString", socket, PACKAGE="rzmq2")
+    .Call("receiveString", socket, PACKAGE="rzmq")
 }
 
 receive.int <- function(socket) {
-    .Call("receiveInt", socket, PACKAGE="rzmq2")
+    .Call("receiveInt", socket, PACKAGE="rzmq")
 }
 
 receive.double <- function(socket) {
-    .Call("receiveDouble", socket, PACKAGE="rzmq2")
+    .Call("receiveDouble", socket, PACKAGE="rzmq")
 }
 
 poll.socket <- function(sockets, events, timeout=0L) {
@@ -105,7 +105,7 @@ set.hwm <- function(socket, option.value) {
     if(zmq.version() >= "3.0.0") {
         stop("ZMQ_HWM removed from libzmq3")
     } else {
-        .Call("set_hwm",socket, option.value, PACKAGE="rzmq2")
+        .Call("set_hwm",socket, option.value, PACKAGE="rzmq")
     }
 }
 
@@ -113,39 +113,39 @@ set.swap <- function(socket, option.value) {
     if(zmq.version() >= "3.0.0") {
         stop("ZMQ_SWAP removed from libzmq3")
     } else {
-        .Call("set_swap",socket, option.value, PACKAGE="rzmq2")
+        .Call("set_swap",socket, option.value, PACKAGE="rzmq")
     }
 }
 
 set.affinity <- function(socket, option.value) {
-    .Call("set_affinity",socket, option.value, PACKAGE="rzmq2")
+    .Call("set_affinity",socket, option.value, PACKAGE="rzmq")
 }
 
 set.identity <- function(socket, option.value) {
-    .Call("set_identity",socket, option.value, PACKAGE="rzmq2")
+    .Call("set_identity",socket, option.value, PACKAGE="rzmq")
 }
 
 subscribe <- function(socket, option.value) {
-    invisible(.Call("subscribe",socket, option.value, PACKAGE="rzmq2"))
+    invisible(.Call("subscribe",socket, option.value, PACKAGE="rzmq"))
 }
 
 unsubscribe <- function(socket, option.value) {
-    .Call("unsubscribe",socket, option.value, PACKAGE="rzmq2")
+    .Call("unsubscribe",socket, option.value, PACKAGE="rzmq")
 }
 
 set.rate <- function(socket, option.value) {
-    .Call("set_rate",socket, option.value, PACKAGE="rzmq2")
+    .Call("set_rate",socket, option.value, PACKAGE="rzmq")
 }
 
 set.recovery.ivl <- function(socket, option.value) {
-    .Call("set_recovery_ivl",socket, option.value, PACKAGE="rzmq2")
+    .Call("set_recovery_ivl",socket, option.value, PACKAGE="rzmq")
 }
 
 set.recovery.ivl.msec <- function(socket, option.value) {
     if(zmq.version() >= "3.0.0") {
         stop("ZMQ_RECOVERY_IVL_MSEC removed from libzmq3")
     } else {
-        .Call("set_recovery_ivl_msec",socket, option.value, PACKAGE="rzmq2")
+        .Call("set_recovery_ivl_msec",socket, option.value, PACKAGE="rzmq")
     }
 }
 
@@ -153,44 +153,44 @@ set.mcast.loop <- function(socket, option.value) {
     if(zmq.version() >= "3.0.0") {
         stop("ZMQ_MCAST_LOOP removed from libzmq3")
     } else {
-        .Call("set_mcast_loop",socket, option.value, PACKAGE="rzmq2")
+        .Call("set_mcast_loop",socket, option.value, PACKAGE="rzmq")
     }
 }
 
 set.sndbuf <- function(socket, option.value) {
-    .Call("set_sndbuf",socket, option.value, PACKAGE="rzmq2")
+    .Call("set_sndbuf",socket, option.value, PACKAGE="rzmq")
 }
 
 set.rcvbuf <- function(socket, option.value) {
-    .Call("set_rcvbuf",socket, option.value, PACKAGE="rzmq2")
+    .Call("set_rcvbuf",socket, option.value, PACKAGE="rzmq")
 }
 
 set.linger <- function(socket, option.value) {
-    .Call("set_linger",socket, option.value, PACKAGE="rzmq2")
+    .Call("set_linger",socket, option.value, PACKAGE="rzmq")
 }
 
 set.reconnect.ivl <- function(socket, option.value) {
-    .Call("set_reconnect_ivl",socket, option.value, PACKAGE="rzmq2")
+    .Call("set_reconnect_ivl",socket, option.value, PACKAGE="rzmq")
 }
 
 set.zmq.backlog <- function(socket, option.value) {
-    .Call("set_zmq_backlog",socket, option.value, PACKAGE="rzmq2")
+    .Call("set_zmq_backlog",socket, option.value, PACKAGE="rzmq")
 }
 
 set.reconnect.ivl.max <- function(socket, option.value) {
-    .Call("set_reconnect_ivl_max",socket, option.value, PACKAGE="rzmq2")
+    .Call("set_reconnect_ivl_max",socket, option.value, PACKAGE="rzmq")
 }
 
 get.rcvmore <- function(socket) {
-    .Call("get_rcvmore",socket,PACKAGE="rzmq2")
+    .Call("get_rcvmore",socket,PACKAGE="rzmq")
 }
 
 set.send.timeout <- function(socket, option.value) {
-    .Call("set_sndtimeo", socket, option.value, PACKAGE="rzmq2")
+    .Call("set_sndtimeo", socket, option.value, PACKAGE="rzmq")
 }
 
 get.send.timeout <- function(socket) {
-    .Call("get_sndtimeo", socket, PACKAGE="rzmq2")
+    .Call("get_sndtimeo", socket, PACKAGE="rzmq")
 }
 
 #################################################################################
@@ -199,7 +199,7 @@ get.send.timeout <- function(socket) {
 
 zmq.version <- function( x = NULL ){
 
-  version__ <- invisible( .Call("get_zmq_version", PACKAGE="rzmq2") )
+  version__ <- invisible( .Call("get_zmq_version", PACKAGE="rzmq") )
 
   if( is.null( x ) ){
     return( version__ )
@@ -219,17 +219,17 @@ init.context <- function( io_threads = 1 ){
   io_threads <- as.integer( io_threads )
   if( io_threads < 1 )
       stop( 'ERROR: io_threads must be at least 1.\n' )
-  invisible( .Call( "initContext", io_threads, PACKAGE = "rzmq2" ) )
+  invisible( .Call( "initContext", io_threads, PACKAGE = "rzmq" ) )
 }
 
 close.socket <- function( socket ){
-  invisible( .Call( "closeSocket", socket, PACKAGE = "rzmq2" ) )
+  invisible( .Call( "closeSocket", socket, PACKAGE = "rzmq" ) )
 }
 
 get.keypair <- function(){
   if( zmq.version( 'major' ) < 4 )
       stop( 'ERROR: ZeroMQ must be version 4 or newer to use get.keypair.\n' )
-  keypair <- invisible( .Call( "get_keypair", PACKAGE = "rzmq2" ) )
+  keypair <- invisible( .Call( "get_keypair", PACKAGE = "rzmq" ) )
   names( keypair ) <- c( "public", "secret" )
   return( keypair )
 }
@@ -237,13 +237,13 @@ get.keypair <- function(){
 set.curve.server <- function( socket ){
   if( zmq.version( 'major' ) < 4 )
       stop( 'ERROR: ZeroMQ must be version 4 or newer to use set.curve.server.\n' )
-  invisible( .Call( "set_curve_server", socket, PACKAGE = "rzmq2" ) )
+  invisible( .Call( "set_curve_server", socket, PACKAGE = "rzmq" ) )
 }
 
 get.curve.server <- function( socket ){
   if( zmq.version( 'major' ) < 4 )
       stop( 'ERROR: ZeroMQ must be version 4 or newer to use get.curve.server.\n' )
-  curve_server <- invisible( .Call( "get_curve_server", socket, PACKAGE = "rzmq2" ) )
+  curve_server <- invisible( .Call( "get_curve_server", socket, PACKAGE = "rzmq" ) )
   return( curve_server )
 }
 
@@ -251,13 +251,13 @@ get.curve.server <- function( socket ){
 set.public.key <- function( socket, option.value ){
   if( zmq.version( 'major' ) < 4 )
       stop( 'ERROR: ZeroMQ must be version 4 or newer to use set.public.key.\n' )
-  invisible( .Call( "set_key", socket, "PUBLIC", as.character( option.value ), PACKAGE = "rzmq2" ) )
+  invisible( .Call( "set_key", socket, "PUBLIC", as.character( option.value ), PACKAGE = "rzmq" ) )
 }
 
 get.public.key <- function( socket ){
    if( zmq.version( 'major' ) < 4 )
       stop( 'ERROR: ZeroMQ must be version 4 or newer to use get.public.key.\n' )
-  public_key <- invisible( .Call( "get_key", socket, "PUBLIC", PACKAGE = "rzmq2" ) )
+  public_key <- invisible( .Call( "get_key", socket, "PUBLIC", PACKAGE = "rzmq" ) )
   return( public_key )
 }
 
@@ -265,13 +265,13 @@ get.public.key <- function( socket ){
 set.secret.key <- function( socket, option.value ){
   if( zmq.version( 'major' ) < 4 )
       stop( 'ERROR: ZeroMQ must be version 4 or newer to use set.secret.key.\n' )
-  invisible( .Call( "set_key", socket, "SECRET", as.character( option.value ), PACKAGE = "rzmq2" ) )
+  invisible( .Call( "set_key", socket, "SECRET", as.character( option.value ), PACKAGE = "rzmq" ) )
 }
 
 get.secret.key <- function( socket ){
   if( zmq.version( 'major' ) < 4 )
       stop( 'ERROR: ZeroMQ must be version 4 or newer to use get.secret.key.\n' )
-  secret_key <- invisible( .Call( "get_key", socket, "SECRET", PACKAGE = "rzmq2" ) )
+  secret_key <- invisible( .Call( "get_key", socket, "SECRET", PACKAGE = "rzmq" ) )
   return( secret_key )
 }
 
@@ -279,19 +279,19 @@ get.secret.key <- function( socket ){
 set.server.key <- function( socket, option.value ){
   if( zmq.version( 'major' ) < 4 )
       stop( 'ERROR: ZeroMQ must be version 4 or newer to use set.server.key.\n' )
-  invisible( .Call( "set_key", socket, "SERVER", as.character( option.value ), PACKAGE = "rzmq2" ) )
+  invisible( .Call( "set_key", socket, "SERVER", as.character( option.value ), PACKAGE = "rzmq" ) )
 }
 
 get.server.key <- function( socket ){
   if( zmq.version( 'major' ) < 4 )
       stop( 'ERROR: ZeroMQ must be version 4 or newer to use get.server.key.\n' )
-  server_key <- invisible( .Call( "get_key", socket, "SERVER", PACKAGE = "rzmq2" ) )
+  server_key <- invisible( .Call( "get_key", socket, "SERVER", PACKAGE = "rzmq" ) )
   return( server_key )
 }
 
 get.io_threads <- function( context ){
   if( zmq.version( 'major' ) < 4 )
       stop( 'ERROR: ZeroMQ must be version 4 or newer to use get.io_threads.\n' )
-  io_threads <- invisible( .Call( "get_io_threads", context, PACKAGE = "rzmq2" ) )
+  io_threads <- invisible( .Call( "get_io_threads", context, PACKAGE = "rzmq" ) )
   return( io_threads )
 }

--- a/R/rzmq.R
+++ b/R/rzmq.R
@@ -27,9 +27,9 @@ zmq.strerror <- function() {
     .Call("get_zmq_strerror", PACKAGE="rzmq")
 }
 
-init.context <- function() {
-    .Call("initContext", PACKAGE="rzmq")
-}
+## init.context <- function() {
+##     .Call("initContext", PACKAGE="rzmq")
+## }
 
 init.socket <- function(context, socket.type) {
     .Call("initSocket", context, socket.type, PACKAGE="rzmq")
@@ -105,7 +105,7 @@ receive.double <- function(socket) {
 }
 
 poll.socket <- function(sockets, events, timeout=0L) {
-    if (timeout != -1L) timeout <- as.integer(timeout * 1e3)
+    if (timeout != -1L) timeout <- as.integer(timeout * 1000000)
     .Call("pollSocket", sockets, events, timeout)
 }
 
@@ -199,4 +199,70 @@ set.send.timeout <- function(socket, option.value) {
 
 get.send.timeout <- function(socket) {
     .Call("get_sndtimeo", socket, PACKAGE="rzmq")
+}
+
+#################################################################################
+# BDD functions                                                                 #
+#################################################################################
+
+init.context <- function( io_threads = 1L ){
+  io_threads <- as.integer( io_threads )
+  if( io_threads < 1 )
+      stop( 'ERROR: io_threads must be at least 1.\n' )
+  invisible( .Call( "initContext", as.integer( io_threads ), PACKAGE = "rzmq" ) )
+}
+
+
+close.socket <- function( socket ){
+  invisible( .Call( "closeSocket", socket, PACKAGE = "rzmq" ) )
+}
+
+get.keypair <- function(){
+  keypair <- invisible( .Call( "get_keypair", PACKAGE = "rzmq" ) )
+  names( keypair ) <- c( "public", "secret" )
+  return( keypair )
+}
+
+set.curve.server <- function( socket ){
+  invisible( .Call( "set_curve_server", socket, PACKAGE = "rzmq" ) )
+}
+
+get.curve.server <- function( socket ){
+  curve_server <- invisible( .Call( "get_curve_server", socket, PACKAGE = "rzmq" ) )
+  return( curve_server )
+}
+
+
+set.public.key <- function( socket, option.value ){
+  invisible( .Call( "set_key", socket, "PUBLIC", as.character( option.value ), PACKAGE = "rzmq" ) )
+}
+
+get.public.key <- function( socket ){
+  public_key <- invisible( .Call( "get_key", socket, "PUBLIC", PACKAGE = "rzmq" ) )
+  return( public_key )
+}
+
+
+set.secret.key <- function( socket, option.value ){
+  invisible( .Call( "set_key", socket, "SECRET", as.character( option.value ), PACKAGE = "rzmq" ) )
+}
+
+get.secret.key <- function( socket ){
+  secret_key <- invisible( .Call( "get_key", socket, "SECRET", PACKAGE = "rzmq" ) )
+  return( secret_key )
+}
+
+
+set.server.key <- function( socket, option.value ){
+  invisible( .Call( "set_key", socket, "SERVER", as.character( option.value ), PACKAGE = "rzmq" ) )
+}
+
+get.server.key <- function( socket ){
+  server_key <- invisible( .Call( "get_key", socket, "SERVER", PACKAGE = "rzmq" ) )
+  return( server_key )
+}
+
+get.io_threads <- function( context ){
+  io_threads <- invisible( .Call( "get_io_threads", context, PACKAGE = "rzmq" ) )
+  return( io_threads )
 }

--- a/R/rzmq.R
+++ b/R/rzmq.R
@@ -15,36 +15,28 @@
 ## along with this program.  If not, see <http:##www.gnu.org#licenses#>. ##
 ###########################################################################
 
-zmq.version <- function() {
-    .Call("get_zmq_version", PACKAGE="rzmq")
-}
-
 zmq.errno <- function() {
-    .Call("get_zmq_errno", PACKAGE="rzmq")
+    .Call("get_zmq_errno", PACKAGE="rzmq2")
 }
 
 zmq.strerror <- function() {
-    .Call("get_zmq_strerror", PACKAGE="rzmq")
+    .Call("get_zmq_strerror", PACKAGE="rzmq2")
 }
 
-## init.context <- function() {
-##     .Call("initContext", PACKAGE="rzmq")
-## }
-
 init.socket <- function(context, socket.type) {
-    .Call("initSocket", context, socket.type, PACKAGE="rzmq")
+    .Call("initSocket", context, socket.type, PACKAGE="rzmq2")
 }
 
 bind.socket <- function(socket, address) {
-    invisible(.Call("bindSocket", socket, address, PACKAGE="rzmq"))
+    invisible(.Call("bindSocket", socket, address, PACKAGE="rzmq2"))
 }
 
 connect.socket <- function(socket, address) {
-    invisible(.Call("connectSocket", socket, address, PACKAGE="rzmq"))
+    invisible(.Call("connectSocket", socket, address, PACKAGE="rzmq2"))
 }
 
 disconnect.socket <- function(socket, address) {
-    invisible(.Call("disconnectSocket", socket, address, PACKAGE="rzmq"))
+    invisible(.Call("disconnectSocket", socket, address, PACKAGE="rzmq2"))
 }
 
 send.socket <- function(socket, data, send.more=FALSE, serialize=TRUE,
@@ -53,19 +45,19 @@ send.socket <- function(socket, data, send.more=FALSE, serialize=TRUE,
         data <- serialize(data, NULL, xdr=xdr)
     }
 
-    invisible(.Call("sendSocket", socket, data, send.more, PACKAGE="rzmq"))
+    invisible(.Call("sendSocket", socket, data, send.more, PACKAGE="rzmq2"))
 }
 
 send.null.msg <- function(socket, send.more=FALSE) {
-    .Call("sendNullMsg", socket, send.more, PACKAGE="rzmq")
+    .Call("sendNullMsg", socket, send.more, PACKAGE="rzmq2")
 }
 
 receive.null.msg <- function(socket) {
-    .Call("receiveNullMsg", socket, PACKAGE="rzmq")
+    .Call("receiveNullMsg", socket, PACKAGE="rzmq2")
 }
 
 receive.socket <- function(socket, unserialize=TRUE,dont.wait=FALSE) {
-    ans <- .Call("receiveSocket", socket, dont.wait, PACKAGE="rzmq")
+    ans <- .Call("receiveSocket", socket, dont.wait, PACKAGE="rzmq2")
 
     if(!is.null(ans) && unserialize) {
         ans <- unserialize(ans)
@@ -89,19 +81,19 @@ send.multipart <- function(socket, parts) {
 }
 
 send.raw.string <- function(socket,data,send.more=FALSE) {
-    .Call("sendRawString", socket, data, send.more, PACKAGE="rzmq")
+    .Call("sendRawString", socket, data, send.more, PACKAGE="rzmq2")
 }
 
 receive.string <- function(socket) {
-    .Call("receiveString", socket, PACKAGE="rzmq")
+    .Call("receiveString", socket, PACKAGE="rzmq2")
 }
 
 receive.int <- function(socket) {
-    .Call("receiveInt", socket, PACKAGE="rzmq")
+    .Call("receiveInt", socket, PACKAGE="rzmq2")
 }
 
 receive.double <- function(socket) {
-    .Call("receiveDouble", socket, PACKAGE="rzmq")
+    .Call("receiveDouble", socket, PACKAGE="rzmq2")
 }
 
 poll.socket <- function(sockets, events, timeout=0L) {
@@ -113,7 +105,7 @@ set.hwm <- function(socket, option.value) {
     if(zmq.version() >= "3.0.0") {
         stop("ZMQ_HWM removed from libzmq3")
     } else {
-        .Call("set_hwm",socket, option.value, PACKAGE="rzmq")
+        .Call("set_hwm",socket, option.value, PACKAGE="rzmq2")
     }
 }
 
@@ -121,39 +113,39 @@ set.swap <- function(socket, option.value) {
     if(zmq.version() >= "3.0.0") {
         stop("ZMQ_SWAP removed from libzmq3")
     } else {
-        .Call("set_swap",socket, option.value, PACKAGE="rzmq")
+        .Call("set_swap",socket, option.value, PACKAGE="rzmq2")
     }
 }
 
 set.affinity <- function(socket, option.value) {
-    .Call("set_affinity",socket, option.value, PACKAGE="rzmq")
+    .Call("set_affinity",socket, option.value, PACKAGE="rzmq2")
 }
 
 set.identity <- function(socket, option.value) {
-    .Call("set_identity",socket, option.value, PACKAGE="rzmq")
+    .Call("set_identity",socket, option.value, PACKAGE="rzmq2")
 }
 
 subscribe <- function(socket, option.value) {
-    invisible(.Call("subscribe",socket, option.value, PACKAGE="rzmq"))
+    invisible(.Call("subscribe",socket, option.value, PACKAGE="rzmq2"))
 }
 
 unsubscribe <- function(socket, option.value) {
-    .Call("unsubscribe",socket, option.value, PACKAGE="rzmq")
+    .Call("unsubscribe",socket, option.value, PACKAGE="rzmq2")
 }
 
 set.rate <- function(socket, option.value) {
-    .Call("set_rate",socket, option.value, PACKAGE="rzmq")
+    .Call("set_rate",socket, option.value, PACKAGE="rzmq2")
 }
 
 set.recovery.ivl <- function(socket, option.value) {
-    .Call("set_recovery_ivl",socket, option.value, PACKAGE="rzmq")
+    .Call("set_recovery_ivl",socket, option.value, PACKAGE="rzmq2")
 }
 
 set.recovery.ivl.msec <- function(socket, option.value) {
     if(zmq.version() >= "3.0.0") {
         stop("ZMQ_RECOVERY_IVL_MSEC removed from libzmq3")
     } else {
-        .Call("set_recovery_ivl_msec",socket, option.value, PACKAGE="rzmq")
+        .Call("set_recovery_ivl_msec",socket, option.value, PACKAGE="rzmq2")
     }
 }
 
@@ -161,108 +153,145 @@ set.mcast.loop <- function(socket, option.value) {
     if(zmq.version() >= "3.0.0") {
         stop("ZMQ_MCAST_LOOP removed from libzmq3")
     } else {
-        .Call("set_mcast_loop",socket, option.value, PACKAGE="rzmq")
+        .Call("set_mcast_loop",socket, option.value, PACKAGE="rzmq2")
     }
 }
 
 set.sndbuf <- function(socket, option.value) {
-    .Call("set_sndbuf",socket, option.value, PACKAGE="rzmq")
+    .Call("set_sndbuf",socket, option.value, PACKAGE="rzmq2")
 }
 
 set.rcvbuf <- function(socket, option.value) {
-    .Call("set_rcvbuf",socket, option.value, PACKAGE="rzmq")
+    .Call("set_rcvbuf",socket, option.value, PACKAGE="rzmq2")
 }
 
 set.linger <- function(socket, option.value) {
-    .Call("set_linger",socket, option.value, PACKAGE="rzmq")
+    .Call("set_linger",socket, option.value, PACKAGE="rzmq2")
 }
 
 set.reconnect.ivl <- function(socket, option.value) {
-    .Call("set_reconnect_ivl",socket, option.value, PACKAGE="rzmq")
+    .Call("set_reconnect_ivl",socket, option.value, PACKAGE="rzmq2")
 }
 
 set.zmq.backlog <- function(socket, option.value) {
-    .Call("set_zmq_backlog",socket, option.value, PACKAGE="rzmq")
+    .Call("set_zmq_backlog",socket, option.value, PACKAGE="rzmq2")
 }
 
 set.reconnect.ivl.max <- function(socket, option.value) {
-    .Call("set_reconnect_ivl_max",socket, option.value, PACKAGE="rzmq")
+    .Call("set_reconnect_ivl_max",socket, option.value, PACKAGE="rzmq2")
 }
 
 get.rcvmore <- function(socket) {
-    .Call("get_rcvmore",socket,PACKAGE="rzmq")
+    .Call("get_rcvmore",socket,PACKAGE="rzmq2")
 }
 
 set.send.timeout <- function(socket, option.value) {
-    .Call("set_sndtimeo", socket, option.value, PACKAGE="rzmq")
+    .Call("set_sndtimeo", socket, option.value, PACKAGE="rzmq2")
 }
 
 get.send.timeout <- function(socket) {
-    .Call("get_sndtimeo", socket, PACKAGE="rzmq")
+    .Call("get_sndtimeo", socket, PACKAGE="rzmq2")
 }
 
 #################################################################################
-# BDD functions                                                                 #
+#  BDD functions
 #################################################################################
 
-init.context <- function( io_threads = 1L ){
+zmq.version <- function( x = NULL ){
+
+  version__ <- invisible( .Call("get_zmq_version", PACKAGE="rzmq2") )
+
+  if( is.null( x ) ){
+    return( version__ )
+  }else if( toupper( x ) == 'MAJOR' ){
+    return( as.integer( strsplit( split = '\\.', version__ )[[1]][1] ) )
+  }else if( toupper( x ) == 'MINOR' ){
+    return( as.integer( strsplit( split = '\\.', version__ )[[1]][2] ) )
+  }else if( toupper( x ) == 'PATCH' ){
+    return( as.integer( strsplit( split = '\\.', version__ )[[1]][3] ) )
+  }else{
+    stop( 'ERROR: x must be one of {NULL,"major","minor","patch"}.\n' )
+  } 
+}
+
+
+init.context <- function( io_threads = 1 ){
   io_threads <- as.integer( io_threads )
   if( io_threads < 1 )
       stop( 'ERROR: io_threads must be at least 1.\n' )
-  invisible( .Call( "initContext", as.integer( io_threads ), PACKAGE = "rzmq" ) )
+  invisible( .Call( "initContext", io_threads, PACKAGE = "rzmq2" ) )
 }
 
-
 close.socket <- function( socket ){
-  invisible( .Call( "closeSocket", socket, PACKAGE = "rzmq" ) )
+  invisible( .Call( "closeSocket", socket, PACKAGE = "rzmq2" ) )
 }
 
 get.keypair <- function(){
-  keypair <- invisible( .Call( "get_keypair", PACKAGE = "rzmq" ) )
+  if( zmq.version( 'major' ) < 4 )
+      stop( 'ERROR: ZeroMQ must be version 4 or newer to use get.keypair.\n' )
+  keypair <- invisible( .Call( "get_keypair", PACKAGE = "rzmq2" ) )
   names( keypair ) <- c( "public", "secret" )
   return( keypair )
 }
 
 set.curve.server <- function( socket ){
-  invisible( .Call( "set_curve_server", socket, PACKAGE = "rzmq" ) )
+  if( zmq.version( 'major' ) < 4 )
+      stop( 'ERROR: ZeroMQ must be version 4 or newer to use set.curve.server.\n' )
+  invisible( .Call( "set_curve_server", socket, PACKAGE = "rzmq2" ) )
 }
 
 get.curve.server <- function( socket ){
-  curve_server <- invisible( .Call( "get_curve_server", socket, PACKAGE = "rzmq" ) )
+  if( zmq.version( 'major' ) < 4 )
+      stop( 'ERROR: ZeroMQ must be version 4 or newer to use get.curve.server.\n' )
+  curve_server <- invisible( .Call( "get_curve_server", socket, PACKAGE = "rzmq2" ) )
   return( curve_server )
 }
 
 
 set.public.key <- function( socket, option.value ){
-  invisible( .Call( "set_key", socket, "PUBLIC", as.character( option.value ), PACKAGE = "rzmq" ) )
+  if( zmq.version( 'major' ) < 4 )
+      stop( 'ERROR: ZeroMQ must be version 4 or newer to use set.public.key.\n' )
+  invisible( .Call( "set_key", socket, "PUBLIC", as.character( option.value ), PACKAGE = "rzmq2" ) )
 }
 
 get.public.key <- function( socket ){
-  public_key <- invisible( .Call( "get_key", socket, "PUBLIC", PACKAGE = "rzmq" ) )
+   if( zmq.version( 'major' ) < 4 )
+      stop( 'ERROR: ZeroMQ must be version 4 or newer to use get.public.key.\n' )
+  public_key <- invisible( .Call( "get_key", socket, "PUBLIC", PACKAGE = "rzmq2" ) )
   return( public_key )
 }
 
 
 set.secret.key <- function( socket, option.value ){
-  invisible( .Call( "set_key", socket, "SECRET", as.character( option.value ), PACKAGE = "rzmq" ) )
+  if( zmq.version( 'major' ) < 4 )
+      stop( 'ERROR: ZeroMQ must be version 4 or newer to use set.secret.key.\n' )
+  invisible( .Call( "set_key", socket, "SECRET", as.character( option.value ), PACKAGE = "rzmq2" ) )
 }
 
 get.secret.key <- function( socket ){
-  secret_key <- invisible( .Call( "get_key", socket, "SECRET", PACKAGE = "rzmq" ) )
+  if( zmq.version( 'major' ) < 4 )
+      stop( 'ERROR: ZeroMQ must be version 4 or newer to use get.secret.key.\n' )
+  secret_key <- invisible( .Call( "get_key", socket, "SECRET", PACKAGE = "rzmq2" ) )
   return( secret_key )
 }
 
 
 set.server.key <- function( socket, option.value ){
-  invisible( .Call( "set_key", socket, "SERVER", as.character( option.value ), PACKAGE = "rzmq" ) )
+  if( zmq.version( 'major' ) < 4 )
+      stop( 'ERROR: ZeroMQ must be version 4 or newer to use set.server.key.\n' )
+  invisible( .Call( "set_key", socket, "SERVER", as.character( option.value ), PACKAGE = "rzmq2" ) )
 }
 
 get.server.key <- function( socket ){
-  server_key <- invisible( .Call( "get_key", socket, "SERVER", PACKAGE = "rzmq" ) )
+  if( zmq.version( 'major' ) < 4 )
+      stop( 'ERROR: ZeroMQ must be version 4 or newer to use get.server.key.\n' )
+  server_key <- invisible( .Call( "get_key", socket, "SERVER", PACKAGE = "rzmq2" ) )
   return( server_key )
 }
 
 get.io_threads <- function( context ){
-  io_threads <- invisible( .Call( "get_io_threads", context, PACKAGE = "rzmq" ) )
+  if( zmq.version( 'major' ) < 4 )
+      stop( 'ERROR: ZeroMQ must be version 4 or newer to use get.io_threads.\n' )
+  io_threads <- invisible( .Call( "get_io_threads", context, PACKAGE = "rzmq2" ) )
   return( io_threads )
 }

--- a/inst/zmq.hpp
+++ b/inst/zmq.hpp
@@ -396,6 +396,11 @@ namespace zmq
         {
             return ptr;
         }
+
+      void* get_ptr(){
+        return ptr;
+      }
+      
     private:
 
         void *ptr;

--- a/man/close.socket.Rd
+++ b/man/close.socket.Rd
@@ -1,0 +1,40 @@
+\name{close.socket}
+\alias{close.socket}
+\title{Close the connection to a socket.}
+\description{Closes the connection to a socket.}
+\usage{
+close.socket(socket)
+}
+\arguments{
+  \item{socket}{a zmq socket object.}
+}
+
+\value{TRUE if operation succeeds or FALSE if the operation fails}
+
+\references{
+http://www.zeromq.org
+http://api.zeromq.org
+http://zguide.zeromq.org/page:all
+}
+
+\author{
+ZMQ was written by Martin Sustrik <sustrik@250bpm.com> and Martin Lucina <mato@kotelna.sk>.
+rzmq was written by Whit Armstrong.
+}
+
+
+\seealso{
+  \code{\link{connect.socket},\link{bind.socket},\link{receive.socket},\link{send.socket},\link{poll.socket}}
+}
+\examples{\dontrun{
+
+library(rzmq)
+context = init.context()
+in.socket = init.socket(context,"ZMQ_PULL")
+bind.socket(in.socket,"tcp://*:5557")
+
+out.socket = init.socket(context,"ZMQ_PUSH")
+bind.socket(out.socket,"tcp://*:5558")
+}}
+
+\keyword{utilities}

--- a/man/get.curve.server.Rd
+++ b/man/get.curve.server.Rd
@@ -1,0 +1,40 @@
+\name{get.curve.server}
+\alias{get.curve.server}
+\title{Test whether a socket is a Curve server.}
+\description{Test whether a socket is a Curve server.}
+\usage{
+get.curve.server(socket)
+}
+\arguments{
+  \item{socket}{a zmq socket object.}
+}
+
+\value{1 if the socket is a Curve server; 0 otherwise.}
+
+\references{
+http://www.zeromq.org
+http://api.zeromq.org
+http://zguide.zeromq.org/page:all
+}
+
+\author{
+ZMQ was written by Martin Sustrik <sustrik@250bpm.com> and Martin Lucina <mato@kotelna.sk>.
+rzmq was written by Whit Armstrong.
+}
+
+
+\seealso{
+  \code{\link{connect.socket},\link{bind.socket},\link{receive.socket},\link{send.socket},\link{poll.socket}}
+}
+\examples{\dontrun{
+
+library(rzmq)
+context = init.context()
+in.socket = init.socket(context,"ZMQ_PULL")
+bind.socket(in.socket,"tcp://*:5557")
+
+out.socket = init.socket(context,"ZMQ_PUSH")
+bind.socket(out.socket,"tcp://*:5558")
+}}
+
+\keyword{utilities}

--- a/man/get.io_threads.Rd
+++ b/man/get.io_threads.Rd
@@ -1,0 +1,40 @@
+\name{get.io_threads}
+\alias{get.io_threads}
+\title{Get the number of io_threads used by a socket.}
+\description{Get the number of io_threads used by a socket.}
+\usage{
+get.io_threads(context)
+}
+\arguments{
+  \item{context}{a zmq context object.}
+}
+
+\value{An integer value representing the number of io_threads used by a socket.}
+
+\references{
+http://www.zeromq.org
+http://api.zeromq.org
+http://zguide.zeromq.org/page:all
+}
+
+\author{
+ZMQ was written by Martin Sustrik <sustrik@250bpm.com> and Martin Lucina <mato@kotelna.sk>.
+rzmq was written by Whit Armstrong.
+}
+
+
+\seealso{
+  \code{\link{connect.socket},\link{bind.socket},\link{receive.socket},\link{send.socket},\link{poll.socket}}
+}
+\examples{\dontrun{
+
+library(rzmq)
+context = init.context()
+in.socket = init.socket(context,"ZMQ_PULL")
+bind.socket(in.socket,"tcp://*:5557")
+
+out.socket = init.socket(context,"ZMQ_PUSH")
+bind.socket(out.socket,"tcp://*:5558")
+}}
+
+\keyword{utilities}

--- a/man/get.keypair.Rd
+++ b/man/get.keypair.Rd
@@ -1,0 +1,38 @@
+\name{get.keypair}
+\alias{get.keypair}
+\title{Get a public and secret keypair for Curve authentication.}
+\description{Get a public and secret keypair for Curve authentication.}
+\usage{
+get.keypair()
+}
+
+\value{A list of two strings, one representing the public key and one
+  representing the secret key.}
+
+\references{
+http://www.zeromq.org
+http://api.zeromq.org
+http://zguide.zeromq.org/page:all
+}
+
+\author{
+ZMQ was written by Martin Sustrik <sustrik@250bpm.com> and Martin Lucina <mato@kotelna.sk>.
+rzmq was written by Whit Armstrong.
+}
+
+
+\seealso{
+  \code{\link{connect.socket},\link{bind.socket},\link{receive.socket},\link{send.socket},\link{poll.socket}}
+}
+\examples{\dontrun{
+
+library(rzmq)
+context = init.context()
+in.socket = init.socket(context,"ZMQ_PULL")
+bind.socket(in.socket,"tcp://*:5557")
+
+out.socket = init.socket(context,"ZMQ_PUSH")
+bind.socket(out.socket,"tcp://*:5558")
+}}
+
+\keyword{utilities}

--- a/man/get.public.key.Rd
+++ b/man/get.public.key.Rd
@@ -1,0 +1,40 @@
+\name{get.public.key}
+\alias{get.public.key}
+\title{Get the public key associated with a socket.}
+\description{Get the public key associated with a socket.}
+\usage{
+get.public.key(socket)
+}
+\arguments{
+  \item{socket}{a zmq socket object.}
+}
+
+\value{A string representing the public key of the socket.}
+
+\references{
+http://www.zeromq.org
+http://api.zeromq.org
+http://zguide.zeromq.org/page:all
+}
+
+\author{
+ZMQ was written by Martin Sustrik <sustrik@250bpm.com> and Martin Lucina <mato@kotelna.sk>.
+rzmq was written by Whit Armstrong.
+}
+
+
+\seealso{
+  \code{\link{connect.socket},\link{bind.socket},\link{receive.socket},\link{send.socket},\link{poll.socket}}
+}
+\examples{\dontrun{
+
+library(rzmq)
+context = init.context()
+in.socket = init.socket(context,"ZMQ_PULL")
+bind.socket(in.socket,"tcp://*:5557")
+
+out.socket = init.socket(context,"ZMQ_PUSH")
+bind.socket(out.socket,"tcp://*:5558")
+}}
+
+\keyword{utilities}

--- a/man/get.secret.key.Rd
+++ b/man/get.secret.key.Rd
@@ -1,0 +1,40 @@
+\name{get.secret.key}
+\alias{get.secret.key}
+\title{Get the secret key associated with a socket.}
+\description{Get the secret key associated with a socket.}
+\usage{
+get.secret.key(socket)
+}
+\arguments{
+  \item{socket}{a zmq socket object.}
+}
+
+\value{A string representing the secret key of the socket.}
+
+\references{
+http://www.zeromq.org
+http://api.zeromq.org
+http://zguide.zeromq.org/page:all
+}
+
+\author{
+ZMQ was written by Martin Sustrik <sustrik@250bpm.com> and Martin Lucina <mato@kotelna.sk>.
+rzmq was written by Whit Armstrong.
+}
+
+
+\seealso{
+  \code{\link{connect.socket},\link{bind.socket},\link{receive.socket},\link{send.socket},\link{poll.socket}}
+}
+\examples{\dontrun{
+
+library(rzmq)
+context = init.context()
+in.socket = init.socket(context,"ZMQ_PULL")
+bind.socket(in.socket,"tcp://*:5557")
+
+out.socket = init.socket(context,"ZMQ_PUSH")
+bind.socket(out.socket,"tcp://*:5558")
+}}
+
+\keyword{utilities}

--- a/man/get.server.key.Rd
+++ b/man/get.server.key.Rd
@@ -1,0 +1,40 @@
+\name{get.server.key}
+\alias{get.server.key}
+\title{Get the server key associated with a client socket.}
+\description{Get the server key associated with a client socket.}
+\usage{
+get.server.key(socket)
+}
+\arguments{
+  \item{socket}{a zmq socket object.}
+}
+
+\value{A string representing the server key of the socket.}
+
+\references{
+http://www.zeromq.org
+http://api.zeromq.org
+http://zguide.zeromq.org/page:all
+}
+
+\author{
+ZMQ was written by Martin Sustrik <sustrik@250bpm.com> and Martin Lucina <mato@kotelna.sk>.
+rzmq was written by Whit Armstrong.
+}
+
+
+\seealso{
+  \code{\link{connect.socket},\link{bind.socket},\link{receive.socket},\link{send.socket},\link{poll.socket}}
+}
+\examples{\dontrun{
+
+library(rzmq)
+context = init.context()
+in.socket = init.socket(context,"ZMQ_PULL")
+bind.socket(in.socket,"tcp://*:5557")
+
+out.socket = init.socket(context,"ZMQ_PUSH")
+bind.socket(out.socket,"tcp://*:5558")
+}}
+
+\keyword{utilities}

--- a/man/init.context.Rd
+++ b/man/init.context.Rd
@@ -8,11 +8,12 @@
   initailize zmq context and zmq socket for to be used for further zmq operations.
 }
 \usage{
-init.context()
+init.context(io_threads)
 init.socket(context, socket.type)
 }
 
 \arguments{
+  \item{io_threads}{(optional) The number of io_threads to use. Defaults to 1.}
   \item{context}{returns a zmq context object.}
   \item{socket.type}{ The ZMQ socket type requested
     e.g. ZMQ_REQ,ZMQ_REP,ZMQ_PULL,ZMQ_PUSH, etc.}

--- a/man/set.curve.server.Rd
+++ b/man/set.curve.server.Rd
@@ -1,0 +1,40 @@
+\name{set.curve.server}
+\alias{set.curve.server}
+\title{Set a socket to be a Curve server.}
+\description{Set a socket to be a Curve server.}
+\usage{
+set.curve.server(socket)
+}
+\arguments{
+  \item{socket}{a zmq socket object.}
+}
+
+\value{TRUE if operation succeeds or FALSE if the operation fails}
+
+\references{
+http://www.zeromq.org
+http://api.zeromq.org
+http://zguide.zeromq.org/page:all
+}
+
+\author{
+ZMQ was written by Martin Sustrik <sustrik@250bpm.com> and Martin Lucina <mato@kotelna.sk>.
+rzmq was written by Whit Armstrong.
+}
+
+
+\seealso{
+  \code{\link{connect.socket},\link{bind.socket},\link{receive.socket},\link{send.socket},\link{poll.socket}}
+}
+\examples{\dontrun{
+
+library(rzmq)
+context = init.context()
+in.socket = init.socket(context,"ZMQ_PULL")
+bind.socket(in.socket,"tcp://*:5557")
+
+out.socket = init.socket(context,"ZMQ_PUSH")
+bind.socket(out.socket,"tcp://*:5558")
+}}
+
+\keyword{utilities}

--- a/man/set.public.key.Rd
+++ b/man/set.public.key.Rd
@@ -1,0 +1,42 @@
+\name{set.public.key}
+\alias{set.public.key}
+\title{Set the public key associated with a socket.}
+\description{Set the public key associated with a socket.}
+\usage{
+set.public.key(socket,option.value)
+}
+\arguments{
+  \item{socket}{a zmq socket object.}
+  \item{option.value}{A string representing the public key to associate witht
+    the socket.}
+}
+
+\value{TRUE if operation succeeds or FALSE if the operation fails}
+
+\references{
+http://www.zeromq.org
+http://api.zeromq.org
+http://zguide.zeromq.org/page:all
+}
+
+\author{
+ZMQ was written by Martin Sustrik <sustrik@250bpm.com> and Martin Lucina <mato@kotelna.sk>.
+rzmq was written by Whit Armstrong.
+}
+
+
+\seealso{
+  \code{\link{connect.socket},\link{bind.socket},\link{receive.socket},\link{send.socket},\link{poll.socket}}
+}
+\examples{\dontrun{
+
+library(rzmq)
+context = init.context()
+in.socket = init.socket(context,"ZMQ_PULL")
+bind.socket(in.socket,"tcp://*:5557")
+
+out.socket = init.socket(context,"ZMQ_PUSH")
+bind.socket(out.socket,"tcp://*:5558")
+}}
+
+\keyword{utilities}

--- a/man/set.secret.key.Rd
+++ b/man/set.secret.key.Rd
@@ -1,0 +1,42 @@
+\name{set.secret.key}
+\alias{set.secret.key}
+\title{Get the secret key associated with a socket.}
+\description{Get the secret key associated with a socket.}
+\usage{
+set.secret.key(socket,option.value)
+}
+\arguments{
+  \item{socket}{a zmq socket object.}
+  \item{option.value}{A string representing the secret key to associate witht
+    the socket.}
+}
+
+\value{TRUE if operation succeeds or FALSE if the operation fails}
+
+\references{
+http://www.zeromq.org
+http://api.zeromq.org
+http://zguide.zeromq.org/page:all
+}
+
+\author{
+ZMQ was written by Martin Sustrik <sustrik@250bpm.com> and Martin Lucina <mato@kotelna.sk>.
+rzmq was written by Whit Armstrong.
+}
+
+
+\seealso{
+  \code{\link{connect.socket},\link{bind.socket},\link{receive.socket},\link{send.socket},\link{poll.socket}}
+}
+\examples{\dontrun{
+
+library(rzmq)
+context = init.context()
+in.socket = init.socket(context,"ZMQ_PULL")
+bind.socket(in.socket,"tcp://*:5557")
+
+out.socket = init.socket(context,"ZMQ_PUSH")
+bind.socket(out.socket,"tcp://*:5558")
+}}
+
+\keyword{utilities}

--- a/man/set.server.key.Rd
+++ b/man/set.server.key.Rd
@@ -1,0 +1,42 @@
+\name{set.server.key}
+\alias{set.server.key}
+\title{Get the server key associated with a client socket.}
+\description{Get the server key associated with a client socket.}
+\usage{
+set.server.key(socket,option.value)
+}
+\arguments{
+  \item{socket}{a zmq socket object.}
+  \item{option.value}{A string representing the server key to associate witht
+    the socket.}
+}
+
+\value{TRUE if operation succeeds or FALSE if the operation fails}
+
+\references{
+http://www.zeromq.org
+http://api.zeromq.org
+http://zguide.zeromq.org/page:all
+}
+
+\author{
+ZMQ was written by Martin Sustrik <sustrik@250bpm.com> and Martin Lucina <mato@kotelna.sk>.
+rzmq was written by Whit Armstrong.
+}
+
+
+\seealso{
+  \code{\link{connect.socket},\link{bind.socket},\link{receive.socket},\link{send.socket},\link{poll.socket}}
+}
+\examples{\dontrun{
+
+library(rzmq)
+context = init.context()
+in.socket = init.socket(context,"ZMQ_PULL")
+bind.socket(in.socket,"tcp://*:5557")
+
+out.socket = init.socket(context,"ZMQ_PUSH")
+bind.socket(out.socket,"tcp://*:5558")
+}}
+
+\keyword{utilities}

--- a/man/zmq.version.Rd
+++ b/man/zmq.version.Rd
@@ -7,12 +7,24 @@
   return the version string of the system zmq library
 }
 \usage{
-zmq.version()
+zmq.version(x=NULL)
 }
 
-\value{
-  a string of the following format: major.minor.patch
+\arguments{
+  \item{x}{The desired level in the version hierarchy.}
 }
+  
+\value{
+  If x == 'major' the return value is an integer representing the ZeroMQ
+  major version.
+  If x == 'minor' the return value is an integer representing the ZeroMQ
+  minor version.
+  If x == 'patch' the return value is an integer representing the ZeroMQ
+  patch.
+  If x is NULL the return value is a string of the following format:
+  major.minor.patch. This is the default.
+}
+
 \references{
   http://www.zeromq.org
   http://api.zeromq.org

--- a/src/interface.h
+++ b/src/interface.h
@@ -31,7 +31,6 @@ extern "C" {
   SEXP get_zmq_version();
   SEXP get_zmq_errno();
   SEXP get_zmq_strerror();
-  SEXP initContext();
   SEXP initSocket(SEXP context_, SEXP socket_type_);
   SEXP bindSocket(SEXP socket_, SEXP address_);
   SEXP connectSocket(SEXP socket_, SEXP address_);
@@ -64,6 +63,24 @@ extern "C" {
   SEXP pollSocket(SEXP socket_, SEXP events_, SEXP timeout_);
   SEXP get_sndtimeo(SEXP socket_);
   SEXP set_sndtimeo(SEXP socket_, SEXP option_value_);
+
+  ///////////////////////////////////////////////////////////////////////////////
+  // BDD functions                                                             //
+  ///////////////////////////////////////////////////////////////////////////////
+
+  SEXP closeSocket( SEXP socket_ );
+
+  SEXP get_keypair();
+  
+  SEXP set_curve_server( SEXP socket_ );
+  SEXP get_curve_server( SEXP socket_ );
+ 
+  SEXP set_key( SEXP socket_, SEXP key_type_, SEXP option_value_ );
+  SEXP get_key( SEXP socket_, SEXP key_type_ );
+
+  SEXP initContext( SEXP io_threads_ );
+
+  SEXP get_io_threads( SEXP context_ );
 }
 
 #endif // INTERFACE_HPP


### PR DESCRIPTION
This pull request exposes several additional functions in a more recent version of ZeroMQ (specifically 4.2.2).

Additionally, the user can specify the number of io_threads to use for server and client sockets.

I have not created new documentation for the additional functions so the following warning appears in R CMD check:

Undocumented code objects:
  ‘close.socket’ ‘get.curve.server’ ‘get.io_threads’ ‘get.keypair’
  ‘get.public.key’ ‘get.secret.key’ ‘get.server.key’ ‘set.curve.server’
  ‘set.public.key’ ‘set.secret.key’ ‘set.server.key’

A warning will also appear in R CMD check because the function signature of close.socket does not follow the signature of the S3 generic base::close.