### PR TITLE
Do not interrupt on SIGWINCH

### DIFF
--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -22,6 +22,7 @@
 #include <zmq.h>
 static_assert(ZMQ_VERSION_MAJOR >= 3,"The minimum required version of libzmq is 3.0.0.");
 #include <zmq.hpp>
+#include <signal.h>
 #include "interface.h"
 
 SEXP get_zmq_version() {
@@ -220,6 +221,7 @@ static short rzmq_build_event_bitmask(SEXP askevents) {
 
 SEXP pollSocket(SEXP sockets_, SEXP events_, SEXP timeout_) {
     SEXP result;
+    signal(SIGWINCH, SIG_IGN);
     
     if(TYPEOF(timeout_) != INTSXP) {
         error("poll timeout must be an integer.");
@@ -425,6 +427,7 @@ SEXP receiveNullMsg(SEXP socket_) {
 SEXP receiveSocket(SEXP socket_, SEXP dont_wait_) {
   SEXP ans;
   zmq::message_t msg;
+  signal(SIGWINCH, SIG_IGN);
 
   if(TYPEOF(dont_wait_) != LGLSXP) {
     REprintf("dont_wait type must be logical (LGLSXP).\n");


### PR DESCRIPTION
System signals sent to R while `rzmq` is receiving data on sockets results in an *Interrupted system call* exception thrown in the functions `receive.socket` and `poll.socket`.

This is in itself not a problem, because that's what interrupts are for. However, one of those interrupts is `SIGWINCH`, which is signaled every time the terminal window in which R runs is resized. The example in the project's [README](https://github.com/ropensci/rzmq/blob/master/README.md) illustrates this problem:

```r
library(rzmq)
context = init.context()
socket = init.socket(context,"ZMQ_REP")
bind.socket(socket,"tcp://*:5555")
msg = receive.socket(socket)
# resize window here (R>=3.3.2)
```

This results [`receiveSocket` to print to `stderr` and return `NULL`](https://github.com/ropensci/rzmq/blob/master/src/interface.cpp#L449), while [`pollSocket` throws an error](https://github.com/ropensci/rzmq/blob/master/src/interface.cpp#L295).<sup>1</sup> In both cases, I have no way of figuring out if I should clean up and terminate (e.g. `SIGINT` from <kbd>Ctrl</kbd>+<kbd>C</kbd>) or just ignore the interrupt.

The changes proposed will ignore the `SIGWINCH` interrupt when receiving or polling and leave all others untouched.

<sup>1</sup> This should probably be consistent (ideally respecting ZeroMQ's error codes for [`zmq_recv`](https://github.com/zeromq/libzmq/blob/3683a96fcbf25c4bc04ac4b002a1b1550db99767/doc/zmq_recv.txt#L50) and [`zmq_poll`](https://github.com/zeromq/libzmq/blob/master/doc/zmq_poll.txt#L91))