### PR TITLE
Use R_CheckUserInterrupt to distinguish interrupts from non-critical signals

### DIFF
--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -32,12 +32,14 @@ static void s_signal_handler (int signal_value) {
 }
 
 static void s_catch_signals (void) {
+#ifdef sigaction
     struct sigaction action;
     action.sa_handler = s_signal_handler;
     action.sa_flags = SA_RESTART;
     sigemptyset (&action.sa_mask);
     sigaction (SIGINT, &action, NULL);
     sigaction (SIGTERM, &action, NULL);
+#endif
 }
 
 SEXP get_zmq_version() {

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -325,14 +325,13 @@ SEXP pollSocket(SEXP sockets_, SEXP events_, SEXP timeout_) {
         if (errno == ETERM)
             error("At least one of the members of the 'items' array refers to "
                   "a 'socket' whose associated 0MQ 'context' was terminated.");
-        if (errno == EFAULT)
+        else if (errno == EFAULT)
             error("The provided 'items' was not valid (NULL).");
     } catch(std::exception& e) {
         error(e.what());
     }
     if (s_interrupted) {
         s_interrupted = 0;
-        raise(SIGINT);
         error("The operation was interrupted by delivery of a signal "
               "before any events were available.");
     }

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -38,7 +38,6 @@ static void s_catch_signals (void) {
     action.sa_flags = SA_RESTART;
     sigemptyset (&action.sa_mask);
     sigaction (SIGINT, &action, NULL);
-    sigaction (SIGTERM, &action, NULL);
 #endif
 }
 


### PR DESCRIPTION
Pull request for #44 .

Tested with:

```r
library(rzmq)
context = init.context()
socket = init.socket(context, "ZMQ_REP")
bind.socket(socket,"tcp://*:5555")
msg = poll.socket(list(socket), list("read"), timeout=5)
```

and signals:

```sh
kill -SIGCHLD $R_PID # list(NULL) as per handler
kill -SIGWINCH $R_PID # list(NULL) as per handler 
kill -SIGINT $R_PID # or Ctrl+C; error message and back to prompt
```

Installing the signal handler was the only way I could find to distinguish between critical (`SIGINT`, `SIGTERM`) and non-critical (`SIGWINCH`, `SIGCHLD`) interrupts.

There is no way to do it using `withCallingHandlers()` in R because `interrupt=...` can not access the signal code it originated from.