### PR TITLE
Allow messages with long vectors

### DIFF
--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -404,8 +404,8 @@ SEXP sendSocket(SEXP socket_, SEXP data_, SEXP send_more_) {
   zmq::socket_t* socket = reinterpret_cast<zmq::socket_t*>(checkExternalPointer(socket_,"zmq::socket_t*"));
   if(!socket) { REprintf("bad socket object.\n");return R_NilValue; }
 
-  zmq::message_t msg (length(data_));
-  memcpy(msg.data(), RAW(data_), length(data_));
+  zmq::message_t msg (Rf_xlength(data_));
+  memcpy(msg.data(), RAW(data_), Rf_xlength(data_));
 
   bool send_more = LOGICAL(send_more_)[0];
   try {
@@ -460,10 +460,10 @@ SEXP initMessage(SEXP data_) {
     return R_NilValue;
   }
 
-  zmq::message_t* msg = new zmq::message_t(length(data_));
-  memcpy(msg->data(), RAW(data_), length(data_));
+  zmq::message_t* msg = new zmq::message_t(Rf_xlength(data_));
+  memcpy(msg->data(), RAW(data_), Rf_xlength(data_));
 // no copy below, see first that one copy works
-//  zmq::message_t msg(reinterpret_cast<void*>(data_), length(data_), NULL);
+//  zmq::message_t msg(reinterpret_cast<void*>(data_), Rf_xlength(data_), NULL);
 
   PROTECT(msg_ = R_MakeExternalPtr(reinterpret_cast<void*>(msg),install("zmq::message_t*"),R_NilValue));
   R_RegisterCFinalizerEx(msg_, messageFinalizer, TRUE);


### PR DESCRIPTION
`rzmq` currently does not allow sending long vectors as messages. Those are array-like objects whose size is bigger than the integer maximum.

```r
.Machine$integer.max
# [1] 2147483647
```

Initializing a message object (or using `rzmq::send.socket`) works with vectors smaller than the integer size maximum,

```r
z = rnorm(2.6e8)
object.size(z)
# 2080000048 bytes
x = rzmq::init.message(z) # works
```

but fails for vectors that are bigger:

```r
z = rnorm(2.7e8)
object.size(z)
# 2160000048 bytes
x = rzmq::init.message(z)
# Error in rzmq::init.message(z) :
#   long vectors not supported yet: ../../src/include/Rinlinedfuns.h:519
```

The reason for this is that the serialized object's length is queried using the `length` function, which returns an integer and triggers an R internal assertion error.

If we instead use `Rf_xlength` (`size_t` type), the length query succeeds and we can serialize larger vectors to `rzmq` messages.

While this could be seen as a guard to not serialize large objects, I would argue that the limit on what makes sense is application specific and packages using `rzmq` should set their own limits.