### PR TITLE
add function to get last bound endpoint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rzmq
 Title: R Bindings for 'ZeroMQ'
-Version: 0.9.7
+Version: 0.9.8
 Authors@R: c(
     person("Whit", "Armstrong", , "armstrong.whit@gmail.com", role = "aut"),
     person("Michael", "Schubert", role = "ctb"),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -38,6 +38,7 @@ export(zmq.version,
        set.zmq.backlog,
        set.reconnect.ivl.max,
        get.rcvmore,
+       get.last.endpoint,
        set.send.timeout,
        get.send.timeout
        )

--- a/R/rzmq.R
+++ b/R/rzmq.R
@@ -204,6 +204,10 @@ get.rcvmore <- function(socket) {
     .Call("get_rcvmore",socket,PACKAGE="rzmq")
 }
 
+get.last.endpoint <- function(socket) {
+    .Call("get_last_endpoint", socket, PACKAGE="rzmq")
+}
+
 set.send.timeout <- function(socket, option.value) {
     .Call("set_sndtimeo", socket, option.value, PACKAGE="rzmq")
 }

--- a/man/socket.options.Rd
+++ b/man/socket.options.Rd
@@ -16,6 +16,7 @@
 \alias{set.zmq.backlog}
 \alias{set.reconnect.ivl.max}
 \alias{get.rcvmore}
+\alias{get.last.endpoint}
 \alias{get.send.timeout}
 \alias{set.send.timeout}
 
@@ -46,6 +47,7 @@ set.reconnect.ivl(socket, option.value)
 set.zmq.backlog(socket, option.value)
 set.reconnect.ivl.max(socket, option.value)
 get.rcvmore(socket)
+get.last.endpoint(socket)
 get.send.timeout(socket)
 set.send.timeout(socket, option.value)
 

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -1017,6 +1017,24 @@ SEXP set_sndtimeo(SEXP socket_, SEXP option_value_) {
   return ans;
 }
 
+SEXP get_last_endpoint(SEXP socket_) {
+
+  zmq::socket_t* socket = reinterpret_cast<zmq::socket_t*>(checkExternalPointer(socket_,"zmq::socket_t*"));
+  if(!socket) { REprintf("bad socket object.\n");return R_NilValue; }
+  char option_value[1024];
+  size_t option_value_len = sizeof(option_value);
+  try {
+    socket->getsockopt(ZMQ_LAST_ENDPOINT, option_value, &option_value_len);
+  } catch(std::exception& e) {
+    REprintf("%s\n",e.what());
+    return R_NilValue;
+  }
+  SEXP ans; PROTECT(ans = allocVector(STRSXP,1));
+  SET_STRING_ELT(ans, 0, mkChar(option_value));
+  UNPROTECT(1);
+  return ans;
+}
+
 SEXP get_sndtimeo(SEXP socket_) {
 
   zmq::socket_t* socket = reinterpret_cast<zmq::socket_t*>(checkExternalPointer(socket_,"zmq::socket_t*"));

--- a/src/interface.h
+++ b/src/interface.h
@@ -65,6 +65,7 @@ extern "C" {
   SEXP set_reconnect_ivl_max(SEXP socket_, SEXP option_value_);
   SEXP get_rcvmore(SEXP socket_);
   SEXP pollSocket(SEXP socket_, SEXP events_, SEXP timeout_);
+  SEXP get_last_endpoint(SEXP socket_);
   SEXP get_sndtimeo(SEXP socket_);
   SEXP set_sndtimeo(SEXP socket_, SEXP option_value_);
 }


### PR DESCRIPTION
Add an API call for getting the last bound address via socket option.

Usage is the following:

```r
library(rzmq)
context = init.context()
socket = init.socket(context,"ZMQ_REP")
bind.socket(socket,"tcp://127.0.0.1:*")
get.last.endpoint(socket)
# "tcp://127.0.0.1:44295"
```

This is useful when e.g. binding on interfaces instead of IPs or when binding automatic ports.

Simple code addition, I don't see the possibility that this could introduce any kind of regression.

Functionality is documented in ZeroMQ [legacy](http://api.zeromq.org/3-2:zmq-getsockopt) branch (`0.3.2`) as well as [current](http://api.zeromq.org/master:zmq-getsockopt) release.

Change is required for functionality I want to add in the next `clustermq` release (https://github.com/mschubert/clustermq/issues/170).