### PR TITLE
change connect.socket in poll.socket example from * to localhost

### DIFF
--- a/man/poll.socket.Rd
+++ b/man/poll.socket.Rd
@@ -37,7 +37,7 @@ in.socket = init.socket(context,"ZMQ_REP")
 bind.socket(in.socket,"tcp://*:5557")
 
 out.socket = init.socket(context,"ZMQ_REQ")
-connect.socket(out.socket,"tcp://*:5557")
+connect.socket(out.socket,"tcp://localhost:5557")
 
 # Poll the REP and REQ sockets for all events.
 events <- poll.socket(list(in.socket, out.socket),


### PR DESCRIPTION
The `poll.socket()` example left me with an error at the changed line;
Binding on all endpoints with `connect.socket()` as per the example yields the following:
```
> connect.socket(out.socket,"tcp://*:5557")
Invalid argument
```
With associated errors:
```
> zmq.errno()
[1] 22
> zmq.strerror()
[1] "Invalid argument"
```

Specifying `"tcp://localhost:5557"` as endpoint ensures appropriate connection, and fixes the issue.